### PR TITLE
AIO-3225 Update sso_signon gem to support docker environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run:
           name: install bundler
-          command: gem install bundler
+          command: gem install bundler -v '~> 2.3.27'
 
       - run:
           name: install dependencies

--- a/lib/sso_openid/urls.yml
+++ b/lib/sso_openid/urls.yml
@@ -37,6 +37,16 @@ development:
   evo:
     host: "n4g.be:3000"
     fqdn: "http://basic.n4g.be:3000"
+docker:
+  portal:
+    host: "portal:3200"
+    fqdn: "http://portal:3200"
+  dms:
+    host: "dm:3000"
+    fqdn: "http://dm:3000"
+  evo:
+    host: "fp:3100"
+    fqdn: "http://fp:3100"
 demo:
   sso_openid:
     host: "identity-sandbox.networkforgood.org"


### PR DESCRIPTION
Donor management is from the existing docker-compose settings. The other two apps haven't been dockerized yet, but the values that are used here will be ported once they are.