### PR TITLE
AIO-3225 Update sso_signon gem to support docker environment

### DIFF
--- a/lib/sso_openid/urls.yml
+++ b/lib/sso_openid/urls.yml
@@ -46,6 +46,16 @@ development:
   evo:
     host: "fp.test"
     fqdn: "http://basic.fp.test"
+docker:
+  portal:
+    host: "portal:3200"
+    fqdn: "http://portal:3200"
+  dms:
+    host: "dm:3000"
+    fqdn: "http://dm:3000"
+  evo:
+    host: "fp:3100"
+    fqdn: "http://fp:3100"
 demo:
   auctions:
     host: "auctions.networkforgood-demo.com"

--- a/lib/sso_openid/version.rb
+++ b/lib/sso_openid/version.rb
@@ -1,3 +1,3 @@
 module SsoOpenid
-  VERSION = "6.0.6"
+  VERSION = "6.0.7"
 end


### PR DESCRIPTION
Donor management is from the existing docker-compose settings. The other two apps haven't been dockerized yet, but the values that are used here will be ported once they are.