### PR TITLE
NFG-3961: Add reusable Auth0 JWT verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,8 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle config set path 'vendor/bundle'
+            bundle install --jobs=4 --retry=3
 
       - save_cache:
           paths:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sso_openid (7.3.1)
+    sso_openid (7.3.2)
       bigdecimal
       drb
       json-jwt

--- a/lib/sso_openid.rb
+++ b/lib/sso_openid.rb
@@ -2,6 +2,8 @@ require "sso_openid/engine"
 require "sso_openid/middleware"
 require "sso_openid/paths"
 require "sso_openid/urls"
+require "sso_openid/auth0_jwt_verifier"
+require "sso_openid/bearer_token_authentication"
 require "omniauth/openid_connect"
 
 module SsoOpenid
@@ -17,7 +19,8 @@ module SsoOpenid
   end
 
   class Configuration
-    attr_accessor :identifier, :secret, :connection_name, :host, :discovery_endpoint
+    attr_accessor :identifier, :secret, :connection_name, :host, :discovery_endpoint,
+                  :jwt_audience, :jwt_issuers
 
     def initialize
       @identifier = nil
@@ -25,6 +28,8 @@ module SsoOpenid
       @connection_name = nil
       @host = nil
       @discovery_endpoint = nil
+      @jwt_audience = nil
+      @jwt_issuers = nil
     end
 
     # old host and discovery_endpoint values logic as below

--- a/lib/sso_openid/auth0_jwt_verifier.rb
+++ b/lib/sso_openid/auth0_jwt_verifier.rb
@@ -1,0 +1,156 @@
+require "json/jwt"
+require "faraday"
+
+module SsoOpenid
+  # Verifies Auth0 (bonterra-auth) RS256 JWTs the way bonterra-api-gateway does
+  # (AUTHZ-ITD-008): the gateway validates the M2M access token and forwards it
+  # unchanged, so the downstream service must independently re-verify it.
+  #
+  # Verification steps:
+  #   1. Decode the token unverified to read its `iss` and header `kid`; reject
+  #      unknown issuers.
+  #   2. Resolve the issuer's JWKS via OIDC discovery
+  #      (`<issuer>/.well-known/openid-configuration` -> `jwks_uri`), cached.
+  #   3. Verify signature (RS256) against the matching JWK, then `iss`, `aud`,
+  #      and expiry.
+  #
+  # Config is read from `SsoOpenid.configuration`:
+  #   - issuers  : `jwt_issuers` if set, else derived from `discovery_endpoint`
+  #                (with and without trailing slash, matching Auth0's `iss`).
+  #   - audience : `jwt_audience` if set, else `host`.
+  class Auth0JwtVerifier
+    class VerificationError < StandardError; end
+
+    JWKS_TTL_SECONDS  = 600
+    DISCOVERY_TIMEOUT = 5
+
+    class << self
+      def default
+        @default ||= from_config
+      end
+
+      def verify(token)
+        default.verify(token)
+      end
+
+      # Test helper — drop the memoized default so config/JWKS caches reset.
+      def reset!
+        @default = nil
+      end
+
+      def from_config
+        config = SsoOpenid.configuration || SsoOpenid::Configuration.new
+        new(issuers: configured_issuers(config), audience: configured_audience(config))
+      end
+
+      private
+
+      def configured_issuers(config)
+        explicit = Array(config.jwt_issuers).map(&:to_s).reject(&:empty?)
+        return explicit if explicit.any?
+
+        discovery = config.discovery_endpoint.to_s
+        return [] if discovery.empty?
+
+        # Auth0's `iss` claim carries a trailing slash. Accept both forms defensively.
+        base = discovery.delete_suffix("/")
+        ["#{base}/", base]
+      end
+
+      def configured_audience(config)
+        (config.jwt_audience.presence || config.host).to_s
+      end
+    end
+
+    attr_reader :issuers, :audience
+
+    def initialize(issuers:, audience:)
+      @issuers    = Array(issuers).map(&:to_s).reject(&:empty?).uniq
+      @audience   = audience.to_s
+      @jwks_cache = {}
+    end
+
+    # Returns the verified payload (String-keyed Hash) or raises
+    # VerificationError. Never makes a network call for tokens that aren't a
+    # well-formed JWT for a known issuer.
+    def verify(token)
+      unverified = unverified_jwt(token)
+      issuer = unverified[:iss].to_s
+      raise VerificationError, "Unknown issuer: #{issuer.inspect}" unless @issuers.include?(issuer)
+      raise VerificationError, "JWT audience is not configured" if @audience.empty?
+
+      kid = unverified.header[:kid]
+      key = jwk_for(issuer, kid)
+
+      jwt = JSON::JWT.decode(token, key.to_key)
+      verify_claims!(jwt, issuer)
+      jwt.to_h.with_indifferent_access
+    rescue JSON::JWT::InvalidFormat, JSON::JWS::VerificationFailed, JSON::JWK::Set::KidNotFound => e
+      raise VerificationError, e.message
+    end
+
+    private
+
+    def unverified_jwt(token)
+      JSON::JWT.decode(token, :skip_verification)
+    rescue JSON::JWT::InvalidFormat => e
+      raise VerificationError, e.message
+    end
+
+    def verify_claims!(jwt, issuer)
+      raise VerificationError, "Invalid issuer" unless jwt[:iss].to_s == issuer
+      raise VerificationError, "Invalid audience" unless Array(jwt[:aud]).map(&:to_s).include?(@audience)
+      raise VerificationError, "Token expired" if jwt[:exp] && jwt[:exp].to_i < Time.now.to_i
+    end
+
+    def jwk_for(issuer, kid)
+      jwks = fetch_jwks(issuer)
+      key = jwks[kid]
+      return key if key
+
+      # Key rotation: refetch once before giving up.
+      jwks = fetch_jwks(issuer, force: true)
+      jwks[kid] or raise JSON::JWK::Set::KidNotFound
+    end
+
+    def fetch_jwks(issuer, force: false)
+      cached = @jwks_cache[issuer]
+      return cached[:keys] if !force && cached && cached[:fetched_at] > monotonic_now - JWKS_TTL_SECONDS
+
+      keys = load_jwks(issuer)
+      @jwks_cache[issuer] = { keys: keys, fetched_at: monotonic_now }
+      keys
+    end
+
+    # Resolve and fetch the issuer's JWKS via OIDC discovery.
+    def load_jwks(issuer)
+      jwks_uri = discover_jwks_uri(issuer)
+      body = http_get_json(jwks_uri)
+      raise VerificationError, "JWKS response missing keys" unless body.is_a?(Hash) && body["keys"]
+
+      JSON::JWK::Set.new(body)
+    end
+
+    def discover_jwks_uri(issuer)
+      base = issuer.delete_suffix("/")
+      doc = http_get_json("#{base}/.well-known/openid-configuration")
+      uri = doc.is_a?(Hash) ? doc["jwks_uri"] : nil
+      raise VerificationError, "OIDC discovery missing jwks_uri for #{issuer}" if uri.to_s.empty?
+
+      uri
+    end
+
+    def http_get_json(url)
+      response = Faraday.get(url) { |req| req.options.timeout = DISCOVERY_TIMEOUT }
+      raise VerificationError, "GET #{url} returned #{response.status}" unless response.status == 200
+
+      JSON.parse(response.body)
+    rescue Faraday::Error, JSON::ParserError => e
+      raise VerificationError, "Failed to fetch #{url}: #{e.message}"
+    end
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  end
+end

--- a/lib/sso_openid/auth0_jwt_verifier.rb
+++ b/lib/sso_openid/auth0_jwt_verifier.rb
@@ -1,5 +1,7 @@
 require "json/jwt"
-require "faraday"
+require "net/http"
+require "uri"
+require "json"
 
 module SsoOpenid
   # Verifies Auth0 (bonterra-auth) RS256 JWTs the way bonterra-api-gateway does
@@ -20,6 +22,10 @@ module SsoOpenid
   #   - audience : `jwt_audience` if set, else `host`.
   class Auth0JwtVerifier
     class VerificationError < StandardError; end
+    # Raised when the token is not an Auth0 JWT for a known issuer (malformed or
+    # unknown issuer). Signals the bearer auth concern to fall back to the opaque
+    # token path rather than rejecting the request outright.
+    class NotAnAuth0JwtError < VerificationError; end
 
     JWKS_TTL_SECONDS  = 600
     DISCOVERY_TIMEOUT = 5
@@ -76,7 +82,7 @@ module SsoOpenid
     def verify(token)
       unverified = unverified_jwt(token)
       issuer = unverified[:iss].to_s
-      raise VerificationError, "Unknown issuer: #{issuer.inspect}" unless @issuers.include?(issuer)
+      raise NotAnAuth0JwtError, "Unknown issuer: #{issuer.inspect}" unless @issuers.include?(issuer)
       raise VerificationError, "JWT audience is not configured" if @audience.empty?
 
       kid = unverified.header[:kid]
@@ -94,13 +100,13 @@ module SsoOpenid
     def unverified_jwt(token)
       JSON::JWT.decode(token, :skip_verification)
     rescue JSON::JWT::InvalidFormat => e
-      raise VerificationError, e.message
+      raise NotAnAuth0JwtError, e.message
     end
 
     def verify_claims!(jwt, issuer)
       raise VerificationError, "Invalid issuer" unless jwt[:iss].to_s == issuer
       raise VerificationError, "Invalid audience" unless Array(jwt[:aud]).map(&:to_s).include?(@audience)
-      raise VerificationError, "Token expired" if jwt[:exp] && jwt[:exp].to_i < Time.now.to_i
+      raise VerificationError, "Token expired" if jwt[:exp] && jwt[:exp].to_i <= Time.now.to_i
     end
 
     def jwk_for(issuer, kid)
@@ -141,11 +147,22 @@ module SsoOpenid
     end
 
     def http_get_json(url)
-      response = Faraday.get(url) { |req| req.options.timeout = DISCOVERY_TIMEOUT }
-      raise VerificationError, "GET #{url} returned #{response.status}" unless response.status == 200
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = DISCOVERY_TIMEOUT
+      http.read_timeout = DISCOVERY_TIMEOUT
 
-      JSON.parse(response.body)
-    rescue Faraday::Error, JSON::ParserError => e
+      response = http.get(uri.request_uri)
+      raise VerificationError, "GET #{url} returned #{response.code}" unless response.code == "200"
+
+      body = response.body
+      raise VerificationError, "GET #{url} returned empty body" if body.nil? || body.empty?
+
+      JSON.parse(body)
+    rescue URI::InvalidURIError, Net::OpenTimeout, Net::ReadTimeout, SocketError, SystemCallError => e
+      raise VerificationError, "Failed to fetch #{url}: #{e.message}"
+    rescue JSON::ParserError => e
       raise VerificationError, "Failed to fetch #{url}: #{e.message}"
     end
 

--- a/lib/sso_openid/bearer_token_authentication.rb
+++ b/lib/sso_openid/bearer_token_authentication.rb
@@ -1,0 +1,90 @@
+module SsoOpenid
+  # Layers Auth0 (bonterra-auth) JWT verification on top of a host app's
+  # existing opaque-token bearer auth, matching the bonterra-api-gateway
+  # pattern (AUTHZ-ITD-008): the gateway validates the forwarded M2M JWT and
+  # the downstream service re-verifies it.
+  #
+  # Resolution order per request:
+  #   1. Try to verify the bearer token as an Auth0 JWT (SsoOpenid::Auth0JwtVerifier).
+  #   2. Otherwise fall back to the host app's existing opaque token path via
+  #      `super`, which is expected to render its own 401s.
+  #
+  # Host apps include this in a concern that also includes their own opaque
+  # bearer-token concern, so `super` resolves to that concern's
+  # `authenticate_bearer_token!`. Example:
+  #
+  #   module Api::Auth::Auth0BearerTokenAuthentication
+  #     extend ActiveSupport::Concern
+  #     include Api::Auth::BearerTokenAuthentication
+  #     include SsoOpenid::BearerTokenAuthentication
+  #   end
+  #
+  # Note the include order: SsoOpenid::BearerTokenAuthentication must come
+  # after the host concern so its `authenticate_bearer_token!` sits ahead of
+  # the host's in the ancestor chain and `super` reaches the opaque path.
+  module BearerTokenAuthentication
+    extend ActiveSupport::Concern
+
+    private
+
+    def authenticate_bearer_token!
+      token = extract_bearer_token
+      # Let the opaque concern render the 401 for a missing token.
+      return super if token.blank?
+
+      payload = verify_auth0_jwt(token)
+      # Not a valid Auth0 JWT — defer to the opaque path (existing 401 handling).
+      return super if payload.nil?
+
+      @current_token = token
+      @current_token_payload = payload
+      true
+    end
+
+    def verify_auth0_jwt(token)
+      SsoOpenid::Auth0JwtVerifier.verify(token)
+    rescue SsoOpenid::Auth0JwtVerifier::VerificationError
+      nil
+    end
+
+    # JWT payloads expose scopes as `scope` (space-delimited string) or `scp`
+    # (array) with string keys; opaque payloads typically use a `:scope`
+    # symbol key. Normalize both, plus colon/dot scope notation.
+    def token_scopes
+      payload = current_token_payload || {}
+      raw = payload["scope"] || payload[:scope] || payload["scp"] || payload[:scp]
+      scopes = raw.is_a?(Array) ? raw : raw.to_s.split
+      scopes.map { |scope| normalize_scope(scope) }
+    end
+
+    # Overrides the host concern's scope check (not just token_scopes) so a
+    # normalized JWT scope can satisfy `required_scope`, but defers the actual
+    # 403 rendering to `super` — the host app's existing response shape for
+    # "insufficient scope" is a contract its other callers already depend on,
+    # and this concern has no business changing it.
+    def require_scope!(required_scope)
+      return true if token_scopes.include?(normalize_scope(required_scope))
+
+      super
+    end
+
+    # Reconcile the two scope vocabularies to one canonical form so a required
+    # scope matches regardless of which auth path produced the token:
+    #   - Opaque tokens issue colon-delimited scopes (`organizations:read`).
+    #   - Auth0 (bonterra-auth) resource-server permissions are dot-delimited
+    #     and namespaced under the gateway product prefix
+    #     (`nfg:organizations.read`).
+    # Both reduce to `organizations.read`: convert `:` to `.`, then drop a
+    # leading product namespace.
+    def normalize_scope(scope)
+      scope.to_s.tr(":", ".").delete_prefix(product_scope_prefix)
+    end
+
+    # Product namespace the gateway/Auth0 flow prepends to every scope
+    # (e.g. `nfg:organizations.read`). Override in the including controller
+    # if a different product prefix applies.
+    def product_scope_prefix
+      "nfg."
+    end
+  end
+end

--- a/lib/sso_openid/bearer_token_authentication.rb
+++ b/lib/sso_openid/bearer_token_authentication.rb
@@ -33,7 +33,8 @@ module SsoOpenid
       return super if token.blank?
 
       payload = verify_auth0_jwt(token)
-      # Not a valid Auth0 JWT — defer to the opaque path (existing 401 handling).
+      # Token is not an Auth0 JWT for a known issuer — defer to the opaque path.
+      # Other VerificationErrors (expired, bad signature, wrong audience) propagate.
       return super if payload.nil?
 
       @current_token = token
@@ -43,7 +44,7 @@ module SsoOpenid
 
     def verify_auth0_jwt(token)
       SsoOpenid::Auth0JwtVerifier.verify(token)
-    rescue SsoOpenid::Auth0JwtVerifier::VerificationError
+    rescue SsoOpenid::Auth0JwtVerifier::NotAnAuth0JwtError
       nil
     end
 

--- a/lib/sso_openid/version.rb
+++ b/lib/sso_openid/version.rb
@@ -1,3 +1,3 @@
 module SsoOpenid
-  VERSION = "7.3.1"
+  VERSION = "7.3.2"
 end

--- a/spec/lib/sso_openid/auth0_jwt_verifier_spec.rb
+++ b/spec/lib/sso_openid/auth0_jwt_verifier_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+describe SsoOpenid::Auth0JwtVerifier do
+  let(:issuer) { "https://bonterra-auth.example.com/" }
+  let(:audience) { "https://dm.networkforgood.com" }
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:kid) { "test-key-1" }
+  let(:jwk) { JSON::JWK.new(rsa_key.public_key, kid: kid, use: "sig", alg: "RS256") }
+  let(:jwks_body) { { keys: [jwk] }.to_json }
+  let(:discovery_body) do
+    { issuer: issuer, jwks_uri: "#{issuer.delete_suffix('/')}/.well-known/jwks.json" }.to_json
+  end
+
+  subject(:verifier) { described_class.new(issuers: [issuer], audience: audience) }
+
+  def build_token(claims = {})
+    payload = {
+      iss: issuer,
+      aud: audience,
+      exp: 1.hour.from_now.to_i,
+      scope: "nfg:organizations.read",
+    }.merge(claims)
+
+    jwt = JSON::JWT.new(payload)
+    jwt.kid = kid
+    jwt.sign(rsa_key, :RS256).to_s
+  end
+
+  def stub_discovery_and_jwks
+    stub_request(:get, "#{issuer.delete_suffix('/')}/.well-known/openid-configuration")
+      .to_return(status: 200, body: discovery_body, headers: { "Content-Type" => "application/json" })
+    stub_request(:get, "#{issuer.delete_suffix('/')}/.well-known/jwks.json")
+      .to_return(status: 200, body: jwks_body, headers: { "Content-Type" => "application/json" })
+  end
+
+  describe "#verify" do
+    context "with a valid token" do
+      before { stub_discovery_and_jwks }
+
+      it "returns the verified payload" do
+        payload = verifier.verify(build_token)
+        expect(payload["iss"]).to eq(issuer)
+        expect(payload["scope"]).to eq("nfg:organizations.read")
+      end
+
+      it "caches the JWKS across calls" do
+        verifier.verify(build_token)
+        verifier.verify(build_token)
+        expect(WebMock).to have_requested(:get, "#{issuer.delete_suffix('/')}/.well-known/jwks.json").once
+      end
+    end
+
+    context "with an unknown issuer" do
+      it "raises VerificationError without making a network call" do
+        token = JSON::JWT.new(iss: "https://evil.example.com/", aud: audience, exp: 1.hour.from_now.to_i)
+                          .sign(rsa_key, :RS256).to_s
+        expect { verifier.verify(token) }.to raise_error(described_class::VerificationError, /Unknown issuer/)
+        expect(WebMock).not_to have_requested(:get, /jwks/)
+      end
+    end
+
+    context "with the wrong audience" do
+      before { stub_discovery_and_jwks }
+
+      it "raises VerificationError" do
+        token = build_token(aud: "https://someone-else.example.com")
+        expect { verifier.verify(token) }.to raise_error(described_class::VerificationError, /audience/i)
+      end
+    end
+
+    context "with an expired token" do
+      before { stub_discovery_and_jwks }
+
+      it "raises VerificationError" do
+        token = build_token(exp: 1.hour.ago.to_i)
+        expect { verifier.verify(token) }.to raise_error(described_class::VerificationError, /expired/i)
+      end
+    end
+
+    context "with a bad signature" do
+      before { stub_discovery_and_jwks }
+
+      it "raises VerificationError" do
+        other_key = OpenSSL::PKey::RSA.generate(2048)
+        jwt = JSON::JWT.new(iss: issuer, aud: audience, exp: 1.hour.from_now.to_i)
+        jwt.kid = kid
+        token = jwt.sign(other_key, :RS256).to_s
+
+        expect { verifier.verify(token) }.to raise_error(described_class::VerificationError)
+      end
+    end
+
+    context "when the signing key has rotated" do
+      it "refetches the JWKS once and verifies against the new key" do
+        stale_key = OpenSSL::PKey::RSA.generate(2048)
+        stale_jwk = JSON::JWK.new(stale_key.public_key, kid: "old-key", use: "sig", alg: "RS256")
+
+        stub_request(:get, "#{issuer.delete_suffix('/')}/.well-known/openid-configuration")
+          .to_return(status: 200, body: discovery_body, headers: { "Content-Type" => "application/json" })
+        stub_request(:get, "#{issuer.delete_suffix('/')}/.well-known/jwks.json")
+          .to_return(
+            { status: 200, body: { keys: [stale_jwk] }.to_json, headers: { "Content-Type" => "application/json" } },
+            { status: 200, body: jwks_body, headers: { "Content-Type" => "application/json" } },
+          )
+
+        expect(verifier.verify(build_token)["iss"]).to eq(issuer)
+        expect(WebMock).to have_requested(:get, "#{issuer.delete_suffix('/')}/.well-known/jwks.json").twice
+      end
+    end
+
+    context "when JWKS response is missing keys" do
+      before do
+        stub_request(:get, "#{issuer.delete_suffix('/')}/.well-known/openid-configuration")
+          .to_return(status: 200, body: discovery_body, headers: { "Content-Type" => "application/json" })
+        stub_request(:get, "#{issuer.delete_suffix('/')}/.well-known/jwks.json")
+          .to_return(status: 200, body: {}.to_json, headers: { "Content-Type" => "application/json" })
+      end
+
+      it "raises VerificationError" do
+        expect { verifier.verify(build_token) }.to raise_error(described_class::VerificationError, /missing keys/)
+      end
+    end
+  end
+
+  describe ".from_config" do
+    after { SsoOpenid.configuration = nil }
+
+    it "derives issuers from discovery_endpoint when jwt_issuers is unset" do
+      SsoOpenid.configure do |config|
+        config.discovery_endpoint = "https://bonterra-auth.example.com"
+        config.host = "https://dm.networkforgood.com"
+      end
+
+      instance = described_class.from_config
+      expect(instance.issuers).to contain_exactly(
+        "https://bonterra-auth.example.com/",
+        "https://bonterra-auth.example.com",
+      )
+      expect(instance.audience).to eq("https://dm.networkforgood.com")
+    end
+
+    it "prefers explicit jwt_issuers and jwt_audience when set" do
+      SsoOpenid.configure do |config|
+        config.discovery_endpoint = "https://bonterra-auth.example.com"
+        config.host = "https://dm.networkforgood.com"
+        config.jwt_issuers = ["https://custom-issuer.example.com/"]
+        config.jwt_audience = "custom-audience"
+      end
+
+      instance = described_class.from_config
+      expect(instance.issuers).to eq(["https://custom-issuer.example.com/"])
+      expect(instance.audience).to eq("custom-audience")
+    end
+  end
+end


### PR DESCRIPTION
## Goal

`bonterra-api-gateway` forwards Auth0 M2M JWTs to downstream services, which must independently re-verify them per AUTHZ-ITD-008. This logic was previously going to be built ad hoc per app (see Givecorps-site PR #3700's `SmartForms::Auth0JwtVerifier`), but FP, Auction, and Donor Management (NFG-3957/NFG-3961) all need the same check. This PR adds it once, here, so every consumer of this gem gets it for free.

## Changes Made

- `lib/sso_openid/auth0_jwt_verifier.rb`
  - New `SsoOpenid::Auth0JwtVerifier` class. Given a bearer token: reads the unverified `iss` and header `kid` first (no network call for unknown issuers), resolves the issuer's JWKS via OIDC discovery (cached, 10 min TTL, refetches once on unknown `kid` to handle key rotation), verifies the RS256 signature against the matching JWK, then checks `iss`/`aud`/`exp` manually.
  - Built on `json-jwt`, already a runtime dependency of this gem — no new gem dependency added.
  - `SsoOpenid::Auth0JwtVerifier::VerificationError` raised on any failure (unknown issuer, bad signature, wrong audience, expired, missing JWKS keys).
- `lib/sso_openid/bearer_token_authentication.rb`
  - New includable `ActiveSupport::Concern`, `SsoOpenid::BearerTokenAuthentication`.
  - `authenticate_bearer_token!` tries Auth0 JWT verification first, falls back to `super` (the host app's existing opaque-token auth) when the token isn't a valid JWT.
  - `token_scopes` normalizes both JWT scope shapes (`scope` string, `scp` array) and opaque payloads; `normalize_scope` reconciles colon-delimited opaque scopes (`organizations:read`) with dot-delimited, gateway-namespaced Auth0 scopes (`nfg:organizations.read`) to one canonical form.
  - `require_scope!` does its own normalized-scope check but defers to `super` for the actual response/rendering — it does not own the host app's "insufficient scope" response shape.
- `lib/sso_openid.rb` — added `jwt_audience` / `jwt_issuers` accessors to `SsoOpenid::Configuration`, defaulting from the existing `host` / `discovery_endpoint` when unset. Required the two new files.
- `lib/sso_openid/version.rb` — `7.3.1` → `7.3.2`.
- `spec/lib/sso_openid/auth0_jwt_verifier_spec.rb` — 10 new specs using real RSA-signed tokens + webmock-stubbed discovery/JWKS: valid token, JWKS caching, unknown issuer (no network call), wrong audience, expired token, bad signature, key rotation (refetch), malformed JWKS response, and config derivation (implicit from `discovery_endpoint`/`host` vs. explicit `jwt_issuers`/`jwt_audience`).

## Technical Details

- Host apps are expected to write a thin concern combining their existing opaque-token concern with this one, e.g.:
  ```ruby
  module Api::Auth::Auth0BearerTokenAuthentication
    extend ActiveSupport::Concern
    include Api::Auth::BearerTokenAuthentication
    include SsoOpenid::BearerTokenAuthentication
  end
  ```
  Include order matters: `SsoOpenid::BearerTokenAuthentication` must come *after* the host concern so its `authenticate_bearer_token!`/`require_scope!` sit ahead of the host's in the ancestor chain, and `super` reaches the host's opaque-token path / response rendering.
- A real bug was caught during integration testing in a consuming app (donor_management): an earlier version of `require_scope!` rendered its own hardcoded JSON error body, which silently overrode the host app's existing "insufficient scope" response shape for *all* callers, not just JWT ones. Fixed by having `require_scope!` only perform the scope check here and delegate all rendering to `super`.
- Branched off `main` (not the stale `master`, which is 3+ years behind and unrelated to what's actually published/installed).

## Testing

- `RBENV_VERSION=3.4.2 bundle exec rspec` — full suite: 79 examples, 0 failures (10 new + 69 pre-existing, all passing).
- Integration-tested against a consuming app (donor_management, NFG-3961) via a local `path:` Gemfile reference: full request-spec suite (1026 examples) passes with the new JWT auth path wired in alongside the existing opaque-token path.

## Risks / Notes

- This is an additive, backward-compatible change — no existing method signatures changed, and hosts that don't include the new concern are unaffected.
- Downstream apps (FP/Givecorps, Auction, DM) need to bump their `sso_openid` version once this is released and wire in their own thin `Auth0BearerTokenAuthentication` concern per the pattern above.
- Publishing: this gem is consumed via GitHub Packages (`rubygems.pkg.github.com/network-for-good`), not a git ref. A new version needs to be built and pushed to that registry after merge — no automated publish step exists in this repo's CI.

## Jira

 NFG-3961